### PR TITLE
feat(no_std): option to disable `std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,17 @@ categories = [
 ]
 rust-version = "1.78"
 
+[features]
+default = []
+
+## enables std
+std = ["thiserror/std"]
+
 [dependencies]
 hashbrown = "0.15"
-thiserror = "2.0"
+thiserror = { version = "2.0", default-features = false }
 
 [dev-dependencies]
 rstest = "0.25"
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,3 @@ thiserror = { version = "2.0", default-features = false }
 
 [dev-dependencies]
 rstest = "0.25"
-
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ categories = [
 rust-version = "1.78"
 
 [features]
-default = []
+default = ["std"]
 
 ## enables std
 std = ["thiserror/std"]


### PR DESCRIPTION
`thiserror` has `std` feature flag enabled by default, this disables it and adds opt-in std usage by `std` feature flag.