### PR TITLE
ci: add smoketests for no_std targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,22 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build
       - run: cargo test
+  ci-nostd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: thumbv7em-none-eabi
+      - run: cargo build --target thumbv7em-none-eabi --no-default-features
+  ci-nostd-portableatomic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: riscv32imc-unknown-none-elf
+      - run: cargo build --target riscv32imc-unknown-none-elf --no-default-features --features portable-atomic,portable-atomic/unsafe-assume-single-core
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: cargo build --target ${{ matrix.target }} ${{ matrix.args }}
 
       - name: Test
-        if: matrix.target != 'thumbv7em-none-eabi' && matrix.target != 'riscv32imc-unknown-none-elf'
+        if: matrix.run_tests
         run: cargo test --target ${{ matrix.target }}
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,22 +20,27 @@ jobs:
             os: windows-2022
             target: x86_64-pc-windows-msvc
             args: ""
+            run_tests: true
           - name: std (macos)
             os: macos-latest
             target: x86_64-apple-darwin
             args: ""
+            run_tests: true
           - name: std (linux)
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             args: ""
+            run_tests: true
           - name: no_std (thumbv7em)
             os: ubuntu-latest
             target: thumbv7em-none-eabi
             args: "--no-default-features"
+            run_tests: false
           - name: no_std (riscv32 + portable-atomic)
             os: ubuntu-latest
             target: riscv32imc-unknown-none-elf
             args: "--no-default-features --features portable-atomic,portable-atomic/unsafe-assume-single-core"
+            run_tests: false
 
     name: ${{ matrix.name }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,29 +10,36 @@ permissions:
   contents: read
 
 jobs:
-  ci:
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: std
+            target: x86_64-unknown-linux-gnu
+            args: ""
+          - name: no_std (thumbv7em)
+            target: thumbv7em-none-eabi
+            args: "--no-default-features"
+          - name: no_std (riscv32 + portable-atomic)
+            target: riscv32imc-unknown-none-elf
+            args: "--no-default-features --features portable-atomic,portable-atomic/unsafe-assume-single-core"
+
+    name: ${{ matrix.name }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo build
-      - run: cargo test
-  ci-nostd:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
+
       - uses: dtolnay/rust-toolchain@stable
         with:
-          target: thumbv7em-none-eabi
-      - run: cargo build --target thumbv7em-none-eabi --no-default-features
-  ci-nostd-portableatomic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          target: riscv32imc-unknown-none-elf
-      - run: cargo build --target riscv32imc-unknown-none-elf --no-default-features --features portable-atomic,portable-atomic/unsafe-assume-single-core
+          target: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --target ${{ matrix.target }} ${{ matrix.args }}
+
+      - name: Test
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: cargo test
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,29 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: std
+          - name: std (windows)
+            os: windows-2022
+            target: x86_64-pc-windows-msvc
+            args: ""
+          - name: std (macos)
+            os: macos-latest
+            target: x86_64-apple-darwin
+            args: ""
+          - name: std (linux)
+            os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             args: ""
           - name: no_std (thumbv7em)
+            os: ubuntu-latest
             target: thumbv7em-none-eabi
             args: "--no-default-features"
           - name: no_std (riscv32 + portable-atomic)
+            os: ubuntu-latest
             target: riscv32imc-unknown-none-elf
             args: "--no-default-features --features portable-atomic,portable-atomic/unsafe-assume-single-core"
 
@@ -38,8 +49,8 @@ jobs:
         run: cargo build --target ${{ matrix.target }} ${{ matrix.args }}
 
       - name: Test
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: cargo test
+        if: matrix.target != 'thumbv7em-none-eabi' && matrix.target != 'riscv32imc-unknown-none-elf'
+        run: cargo test --target ${{ matrix.target }}
   clippy:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add builds for some common no_std targets to ensure that we don't accidentally break them.

See comment requesting this feature here:
https://github.com/ratatui/kasuari/pull/30#pullrequestreview-3173515552

Will not succeed until #30 is merged because the portable-atomic feature is not present until then.